### PR TITLE
fix hover parameters

### DIFF
--- a/src/star-rating.component.ts
+++ b/src/star-rating.component.ts
@@ -179,7 +179,7 @@ export class StarRatingComponent extends StarRatingController implements OnChang
     }
 
     //Hover events
-    onStarHover(rating: number): void {
+    onStarHover(rating?: number): void {
 
         if (!this.interactionPossible() || !this.hoverEnabled) {
             return;


### PR DESCRIPTION
After getting the error:

`angular-star-rating/src/star-rating.component.ngfactory.ts (778,35): Supplied parameters do not match any signature of call target.`

I fixed the function `onStarHover` to allow no parameters