### PR TITLE
Support angular 5

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -46,8 +46,8 @@
     "css-star-rating": "^1.1.3"
   },
   "peerDependencies": {
-    "@angular/core": "^4.0.0",
-    "@angular/forms": "^4.0.0",
+    "@angular/core": "^4.0.0 || ^5.0.0",
+    "@angular/forms": "^4.0.0 || ^5.0.0",
     "rxjs": "^5.1.0",
     "zone.js": "^0.8.4"
   }


### PR DESCRIPTION
The library seems to be compatible with angular 5, but it throws a warning during installation:

```
npm WARN angular-star-rating@3.0.8 requires a peer of @angular/core@^4.0.0 but none was installed.
npm WARN angular-star-rating@3.0.8 requires a peer of @angular/forms@^4.0.0 but none was installed.
```

It currently also prevents being able to use shrinkwrap, since invalid peer dependencies can't be ignored:

```
npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! peer invalid: @angular/core@^4.0.0, required by angular-star-rating@3.0.8
npm ERR! peer invalid: @angular/forms@^4.0.0, required by angular-star-rating@3.0.8
```

This change expands the version range to allow using the library with either angular 4 or 5.