### PR TITLE
fix: remove default value of getHalfStarVisible

### DIFF
--- a/libs/angular-star-rating/src/lib/components/star-rating/star-rating.component.ts
+++ b/libs/angular-star-rating/src/lib/components/star-rating/star-rating.component.ts
@@ -14,7 +14,7 @@ import { StarRatingUtils } from '../../services/star-rating.utils';
 })
 export class StarRatingComponent extends StarRating {
   @Input()
-  getHalfStarVisible: (rating: number) => boolean = (rating: number) => false;
+  getHalfStarVisible: (rating: number) => boolean;
 
   // @ts-ignore
   @Input() getColor: (


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

Related issue: #128 